### PR TITLE
Customize step location

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.21
+golang 1.23

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,6 +12,7 @@ workflows:
             #!/usr/bin/env bash
             set -ex
             go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+            export PATH="$(go env GOPATH)/bin:$PATH"
             golangci-lint run ./...
     - go-test: {}
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -7,13 +7,11 @@ workflows:
     - go-list: {}
     - script:
         title: golangci-lint
-        deps:
-          brew:
-          - name: golangci-lint
         inputs:
         - content: |
             #!/usr/bin/env bash
             set -ex
+            go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
             golangci-lint run ./...
     - go-test: {}
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,16 @@ workflows:
   test:
     steps:
     - go-list: {}
-    - golint: {}
-    - errcheck: {}
+    - script:
+        title: golangci-lint
+        deps:
+          brew:
+          - name: golangci-lint
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            set -ex
+            golangci-lint run ./...
     - go-test: {}
 
   create-release:

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -34,10 +34,10 @@ var infoCmd = &cobra.Command{
 
 		// by Step ID
 		if len(args) < 1 {
-			return errors.New("No step ID specified as a parameter")
+			return errors.New("no step ID specified as a parameter")
 		}
 		if len(args) > 1 {
-			return fmt.Errorf("More than one step ID specified: %s", args)
+			return fmt.Errorf("more than one step ID specified: %s", args)
 		}
 		stepID := args[0]
 
@@ -48,12 +48,12 @@ var infoCmd = &cobra.Command{
 func printStepInfoFromStepYML(ymlPth string) error {
 	step, err := stepman.ParseStepDefinition(ymlPth, false)
 	if err != nil {
-		return fmt.Errorf("Failed to parse step.yml (path: %s), error: %s", ymlPth, err)
+		return fmt.Errorf("failed to parse step.yml (path: %s), error: %s", ymlPth, err)
 	}
 
 	// inputs, err := getEnvInfos(step.Inputs)
 	// if err != nil {
-	// 	return fmt.Errorf("Failed to get step input infos, err: %s", err)
+	// 	return fmt.Errorf("failed to get step input infos, err: %s", err)
 	// }
 
 	// outputs, err := getEnvInfos(step.Outputs)
@@ -83,22 +83,22 @@ func printStepInfoFromLibrary(stepID string) error {
 	_, stepVersion, err := stepmanutil.ReadStepVersionInfo(collectionID, stepID, stepVersion)
 
 	if err != nil {
-		return fmt.Errorf("Failed to get step info: %s", err)
+		return fmt.Errorf("failed to get step info: %s", err)
 	}
 
 	step, err := stepman.ReadStepVersionInfo(collectionID, stepID, stepVersion)
 	if err != nil {
-		return fmt.Errorf("Failed to read step version info: %s", err)
+		return fmt.Errorf("failed to read step version info: %s", err)
 	}
 
 	collection, err := stepman.ReadStepSpec(collectionID)
 	if err != nil {
-		return fmt.Errorf("Failed to read step lib (%s), error: %s", collectionID, err)
+		return fmt.Errorf("failed to read step lib (%s), error: %s", collectionID, err)
 	}
 
 	latestStepVersion, err := collection.GetLatestStepVersion(stepID)
 	if err != nil {
-		return fmt.Errorf("Failed to get latest version of step (id:%s)", stepID)
+		return fmt.Errorf("failed to get latest version of step (id:%s)", stepID)
 	}
 
 	if stepVersion == "" {
@@ -131,13 +131,13 @@ func printStepInfoFromLibrary(stepID string) error {
 
 	route, found := stepman.ReadRoute(collectionID)
 	if !found {
-		return fmt.Errorf("No route found for collection: %s", collectionID)
+		return fmt.Errorf("no route found for collection: %s", collectionID)
 	}
 	globalStepInfoPth := stepman.GetStepGlobalInfoPath(route, stepID)
 	if globalStepInfoPth != "" {
 		globalInfo, found, err := stepman.ParseStepGroupInfoModel(globalStepInfoPth)
 		if err != nil {
-			return fmt.Errorf("Failed to get step (path:%s) output infos, err: %s", globalStepInfoPth, err)
+			return fmt.Errorf("failed to get step (path:%s) output infos, err: %s", globalStepInfoPth, err)
 		}
 
 		if found {
@@ -228,7 +228,7 @@ func printStepVersionInfoOutput(stepVersionInfo models.StepInfoModel) error {
 
 		inputs, err := getEnvInfos(stepVersionInfo.Step.Inputs)
 		if err != nil {
-			return fmt.Errorf("Failed to get step input infos, err: %s", err)
+			return fmt.Errorf("failed to get step input infos, err: %s", err)
 		}
 
 		for _, input := range inputs {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -32,23 +32,24 @@ func init() {
 
 func printStepList() error {
 	if collection == "" {
-		return errors.New("No collection defined")
+		return errors.New("no collection defined")
 	}
-	if format == "" || format == output.FormatRaw {
+	switch format {
+	case "", output.FormatRaw:
 		out, err := tools.StepmanRawStepList(collection)
 		if err != nil {
-			return fmt.Errorf("Failed to print step list, err: %s", err)
+			return fmt.Errorf("failed to print step list, err: %s", err)
 		}
 		fmt.Println("Step list:")
 		fmt.Println(out)
-	} else if format == output.FormatJSON {
+	case output.FormatJSON:
 		out, err := tools.StepmanJSONStepList(collection)
 		if err != nil {
-			return fmt.Errorf("Failed to print step list, err: %s", err)
+			return fmt.Errorf("failed to print step list, err: %s", err)
 		}
 		fmt.Println(out)
-	} else {
-		return fmt.Errorf("Invalid format: %s", format)
+	default:
+		return fmt.Errorf("invalid format: %s", format)
 	}
 	return nil
 }

--- a/create/create.go
+++ b/create/create.go
@@ -208,7 +208,22 @@ func Step() error {
 		}
 	}
 
-	return createStep(inventoryForCreateStep)
+	stepDirAbsPth, err := defaultStepDir(inventoryForCreateStep)
+	if err != nil {
+		return errors.Wrap(err, "Failed to determine default step directory")
+	}
+	fmt.Println()
+	fmt.Println("Where should the step directory be created?")
+	customDir, err := goinp.AskForStringWithDefault(colorstring.Green("Step directory"), stepDirAbsPth)
+	if err != nil {
+		return errors.Wrap(err, "Failed to determine step directory")
+	}
+	stepDirAbsPth, err = pathutil.AbsPath(customDir)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get absolute path for step directory (%s)", customDir)
+	}
+
+	return createStep(inventoryForCreateStep, stepDirAbsPth)
 }
 
 func readAuthorFromGitConfig() string {
@@ -243,34 +258,12 @@ func stepDirAndRepoNameFromID(stepID string) string {
 	return "bitrise-step-" + stepID
 }
 
-func createStep(inventory InventoryModel) error {
+func defaultStepDir(inventory InventoryModel) (string, error) {
+	return pathutil.AbsPath(stepDirAndRepoNameFromID(inventory.ID))
+}
+
+func createStep(inventory InventoryModel, stepDirAbsPth string) error {
 	fmt.Println()
-
-	// create directory
-	stepDirAbsPth := ""
-	if inventory.ToolkitType == toolkitTypeBash {
-		baseDirPath := stepDirAndRepoNameFromID(inventory.ID)
-		absPth, err := pathutil.AbsPath(baseDirPath)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to get absolute path for step directory (%s)", baseDirPath)
-		}
-		stepDirAbsPth = absPth
-	} else if inventory.ToolkitType == toolkitTypeGo {
-		gopath := os.Getenv("GOPATH")
-		if len(gopath) < 1 {
-			// no GOPATH env set - use "${HOME}/go", which is the default GOPATH since Go 1.8
-			gopath = filepath.Join(pathutil.UserHomeDir(), "go")
-		}
-		baseDirPath := filepath.Join(gopath, "src", inventory.GoToolkitInventory.PackageID)
-
-		absPth, err := pathutil.AbsPath(baseDirPath)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to get absolute path for step directory (%s)", baseDirPath)
-		}
-		stepDirAbsPth = absPth
-	} else {
-		return errors.Errorf("Invalid Toolkit Type: %s", inventory.ToolkitType)
-	}
 
 	printInfoLine("Creating Step directory at:", stepDirAbsPth)
 	if exists, err := pathutil.IsPathExists(stepDirAbsPth); err != nil {

--- a/create/create.go
+++ b/create/create.go
@@ -266,10 +266,8 @@ func createStep(inventory InventoryModel, stepDirAbsPth string) error {
 	fmt.Println()
 
 	printInfoLine("Creating Step directory at:", stepDirAbsPth)
-	if exists, err := pathutil.IsPathExists(stepDirAbsPth); err != nil {
-		return errors.Wrap(err, "Failed to check whether step dir already exists")
-	} else if exists {
-		return errors.Errorf("Directory (%s) already exists!", stepDirAbsPth)
+	if entries, err := os.ReadDir(stepDirAbsPth); err == nil && len(entries) > 0 {
+		return errors.Errorf("Directory (%s) already exists and is not empty!", stepDirAbsPth)
 	}
 	if err := os.MkdirAll(stepDirAbsPth, 0755); err != nil {
 		return errors.Wrap(err, "Failed to create step directory")

--- a/create/create_test.go
+++ b/create/create_test.go
@@ -1,10 +1,24 @@
 package create
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func Test_defaultStepDir(t *testing.T) {
+	inv := InventoryModel{ID: "my-step"}
+	got, err := defaultStepDir(inv)
+	require.NoError(t, err)
+	require.Contains(t, got, "bitrise-step-my-step")
+	require.True(t, filepath.IsAbs(got))
+}
+
+func Test_stepDirAndRepoNameFromID(t *testing.T) {
+	require.Equal(t, "bitrise-step-hello", stepDirAndRepoNameFromID("hello"))
+	require.Equal(t, "bitrise-step-my-step", stepDirAndRepoNameFromID("my-step"))
+}
 
 func Test_generateIDFromString(t *testing.T) {
 	require.Equal(t, "a-simple-test", generateIDFromString("a-simple-test"))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitrise-io/bitrise-plugins-step
 
-go 1.18
+go 1.23
 
 require (
 	github.com/bitrise-io/bitrise v0.0.0-20230707121919-a5b9e2d27ea9

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=

--- a/stepmanutil/stepmanutil.go
+++ b/stepmanutil/stepmanutil.go
@@ -46,16 +46,16 @@ type SpecJSONModel struct {
 func ReadStepCollectionModel(collectionID string) (models.StepCollectionModel, error) {
 	specJSONPath, err := specJSONPathOfCollection(collectionID)
 	if err != nil {
-		return models.StepCollectionModel{}, fmt.Errorf("Failed to get spec json path: %s", err)
+		return models.StepCollectionModel{}, fmt.Errorf("failed to get spec json path: %s", err)
 	}
 
 	file, err := os.Open(specJSONPath)
 	if err != nil {
-		return models.StepCollectionModel{}, fmt.Errorf("Failed to open spec json: %s", err)
+		return models.StepCollectionModel{}, fmt.Errorf("failed to open spec json: %s", err)
 	}
 	var spec models.StepCollectionModel
 	if err := json.NewDecoder(file).Decode(&spec); err != nil {
-		return models.StepCollectionModel{}, fmt.Errorf("Failed to parse spec json: %s", err)
+		return models.StepCollectionModel{}, fmt.Errorf("failed to parse spec json: %s", err)
 	}
 	return spec, nil
 }
@@ -66,21 +66,21 @@ func ReadStepCollectionModel(collectionID string) (models.StepCollectionModel, e
 func ReadStepVersionInfo(collectionID, stepID, stepVersion string) (StepVersionModel, string, error) {
 	specJSONPath, err := specJSONPathOfCollection(collectionID)
 	if err != nil {
-		return StepVersionModel{}, "", fmt.Errorf("Failed to get spec json path: %s", err)
+		return StepVersionModel{}, "", fmt.Errorf("failed to get spec json path: %s", err)
 	}
 
 	file, err := os.Open(specJSONPath)
 	if err != nil {
-		return StepVersionModel{}, "", fmt.Errorf("Failed to open spec json: %s", err)
+		return StepVersionModel{}, "", fmt.Errorf("failed to open spec json: %s", err)
 	}
 	var spec SpecJSONModel
 	if err := json.NewDecoder(file).Decode(&spec); err != nil {
-		return StepVersionModel{}, "", fmt.Errorf("Failed to parse spec json: %s", err)
+		return StepVersionModel{}, "", fmt.Errorf("failed to parse spec json: %s", err)
 	}
 
 	stepInfo, isFound := spec.Steps[stepID]
 	if !isFound {
-		return StepVersionModel{}, "", fmt.Errorf("No Step found for ID: %s", stepID)
+		return StepVersionModel{}, "", fmt.Errorf("no step found for ID: %s", stepID)
 	}
 
 	if stepVersion == "" {
@@ -89,7 +89,7 @@ func ReadStepVersionInfo(collectionID, stepID, stepVersion string) (StepVersionM
 
 	stepVersionInfo, isFound := stepInfo.StepVersions[stepVersion]
 	if !isFound {
-		return StepVersionModel{}, "", fmt.Errorf("No Step version found for (ID: %s) (version: %s)", stepID, stepVersion)
+		return StepVersionModel{}, "", fmt.Errorf("no step version found for (ID: %s) (version: %s)", stepID, stepVersion)
 	}
 
 	return stepVersionInfo, stepVersion, nil
@@ -98,26 +98,26 @@ func ReadStepVersionInfo(collectionID, stepID, stepVersion string) (StepVersionM
 func specJSONPathOfCollection(collectionID string) (string, error) {
 	routesAbsPath, err := pathutil.AbsPath(stepmanRoutesPath)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get absolut path for stepman routing file: %s", err)
+		return "", fmt.Errorf("failed to get absolute path for stepman routing file: %s", err)
 	}
 	bytes, err := fileutil.ReadBytesFromFile(routesAbsPath)
 	if err != nil {
-		return "", fmt.Errorf("Failed to read content of routing file: %s", err)
+		return "", fmt.Errorf("failed to read content of routing file: %s", err)
 	}
 	var routeMap map[string]string
 	if err := json.Unmarshal(bytes, &routeMap); err != nil {
-		return "", fmt.Errorf("Failed to parse content of routing file: %s", err)
+		return "", fmt.Errorf("failed to parse content of routing file: %s", err)
 	}
 
 	val, isFound := routeMap[collectionID]
 	if !isFound {
-		return "", fmt.Errorf("Specified collection (%s) not found in routing", collectionID)
+		return "", fmt.Errorf("specified collection (%s) not found in routing", collectionID)
 	}
 
 	specPath := fmt.Sprintf("~/.stepman/step_collections/%s/spec/spec.json", val)
 	absSpecJSONPath, err := pathutil.AbsPath(specPath)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get absolute path of spec.json")
+		return "", fmt.Errorf("failed to get absolute path of spec.json")
 	}
 
 	return absSpecJSONPath, nil


### PR DESCRIPTION
The current plugin had a couple of annoyances:

* it would put Go steps in the GOPATH even though that is an outdated concept.
* for bash steps it would automatically create a new directory for the step (my habit, and one I bet many users do, is to create the directory, `cd` into it, then run the step creation wizard. This would annoyingly create a subdirectory with all the step contents.)

Letting the user customize the location (while providing a convenient default) solves both problems above.